### PR TITLE
Typo fix in example.skon

### DIFF
--- a/Examples/example.skon
+++ b/Examples/example.skon
@@ -10,7 +10,7 @@
 //The version of this document
 Version: "0.0.1",
 
-VerisionName: "Octopus",
+VersionName: "Octopus",
 
 //A map of the authors details
 Author: {


### PR DESCRIPTION
:octopus: is not pleased by typos
all hail :octopus: 
